### PR TITLE
Added `echoMode` config for changing the echoMode of the password-input

### DIFF
--- a/Login.qml
+++ b/Login.qml
@@ -69,7 +69,15 @@ Column {
 		TermInput {
 			id: passwordInput
 
-			echoMode: TextInput.NoEcho
+			echoMode: {
+				switch (config.echoMode) {
+					case "NoEcho":             return TextInput.NoEcho
+					case "Normal":             return TextInput.Normal
+					case "Password":           return TextInput.Password
+					case "PasswordEchoOnEdit": return TextInput.PasswordEchoOnEdit
+					default:                   return TextInput.NoEcho
+				}
+			}
 			text: ""
 
 			onAccepted: {

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Sample session menu:
 * `fontSize`: The size of the font in points ([reference](https://doc.qt.io/qt-5/qml-qtquick-textinput.html#font.pointSize-prop))
 * `foreground`: The colour of the font ([reference](https://doc.qt.io/qt-5/qml-color.html))
 * `background`: The colour of the background (it will fill the entire screen) ([reference](https://doc.qt.io/qt-5/qml-color.html))
+* `echoMode`: How the password-input works (if the password is visible/masked/hidden) ([reference](https://doc.qt.io/archives/qt-5.15/qml-qtquick-textinput.html#echoMode-prop))  
+  Possible Values:
+   * `NoEcho`
+   * `Normal`
+   * `Password`
+   * `PasswordEchoOnEdit`
 
 ## Note for installation
 If you install from this repository, first run the `scripts/build.sh` script to produce a `build` directory, and use the contents of this directory to install.

--- a/theme.conf
+++ b/theme.conf
@@ -3,3 +3,4 @@ fontFamily=monospace
 fontSize=10
 foreground=white
 background=black
+echoMode=PasswordEchoOnEdit


### PR DESCRIPTION
Hi,

annoyingly often I accidently press a wrong key (or only think I pressed one), and the I have to press _some_ amount of backspace (until I'm sure all characters are cleared), an re-type my password)

I've added an `echoMode` option in the theme.config, with which you can change the echoMode of the TextInput to `TextInput.Password` - which displays the password as dots.  
Of course, this is a bit less secure against shoulder-surfing - but for me that's not really a problem, I live alone - and also teh default is still `NoEcho` and you have to actively change it.  
Also you could change it to `Normal` and display the password in plain - idk, I just allowed all QT enum values, an I guess perhaps someone wants it that way..

![image](https://github.com/user-attachments/assets/5a4d3f8a-ce4f-46c7-a5c4-fe92c2a51796)


Anyway - this change was mostly for me, but perhaps other people would also like it so I created this PR.  
Also thanks for this SDDM theme - I really like it and have been daily driving it for a bit over a year.
